### PR TITLE
Feature/sortable issues

### DIFF
--- a/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
+++ b/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
@@ -8,8 +8,8 @@ $(document).on 'page:change', ->
   # сохранение порядка тикетов, если он изменился
   $('.issues').on 'sortupdate', (event, ui) ->
     column = $(event.target).closest('.board-column').data('column')
-    board_github_name = $('.board').data('github_name')
-    path = "/boards/#{board_github_name}/columns/#{column}"
+    board = $('.board').data('github_full_name')
+    path = "/boards/#{board}/columns/#{column}"
 
     if $(event.target).sortable('serialize')
       issues = $(event.target).sortable('serialize')
@@ -29,7 +29,7 @@ $(document).on 'page:change', ->
     issue_number = $(".ui-sortable-helper").data('number')
     column_number = $(@).data('column')
     $current_issue = $('.issue[data-number="' + issue_number + '"]')
-    board = $('.board').data('github_name')
+    board = $('.board').data('github_full_name')
 
     unless $(".ui-draggable-dragging").data('start_column') == column_number
       $(".ui-draggable-dragging").prependTo($(@).find('.issues'))

--- a/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
+++ b/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
@@ -16,7 +16,6 @@ $(document).on 'page:change', ->
     else
       # колонка стала пустой
       issues =  { issues: ['empty'] }
-      console.log issues
 
     $.ajax
       url: path,
@@ -27,16 +26,16 @@ $(document).on 'page:change', ->
     accept: ".issue"
 
   $(".droppable").on "drop", (event, ui) ->
-    issue = $(".ui-sortable-helper").data('number')
-    column = $(@).data('column')
-    $(".ui-draggable-dragging").removeAttr('style')
+    issue_number = $(".ui-sortable-helper").data('number')
+    column_number = $(@).data('column')
+    $current_issue = $('.issue[data-number="' + issue_number + '"]')
+    board = $('.board').data('github_name')
 
-    unless $(".ui-draggable-dragging").data('start_column') == column
+    unless $(".ui-draggable-dragging").data('start_column') == column_number
       $(".ui-draggable-dragging").prependTo($(@).find('.issues'))
       $(@).removeClass 'over'
-      board_github_name = $('.board').data('github_name')
-      path = "/boards/#{board_github_name}/issues/#{issue}/move_to/#{column}"
-      $.get path
+      move_to_path = "/boards/#{board}/issues/#{issue_number}/move_to/#{column_number}"
+      $.get move_to_path
 
   $(".droppable").on "dropout", (event, ui) ->
     $(@).removeClass 'over'

--- a/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
+++ b/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
@@ -1,46 +1,77 @@
 $(document).on 'page:change', ->
   return unless document.body.id == 'boards_show'
 
-  $(".droppable").droppable ->
-    accept: ".issue"
+  $('.issues').sortable connectWith: '.issues'
+  $('.issues').sortable
+    connectWith: '.issues'
+  $('.issues').disableSelection()
 
-  $(".droppable").on "drop", (event, ui) ->
-    issue = $(".ui-draggable-dragging").data('number')
-    column = $(@).data('column')
-    $(".ui-draggable-dragging").removeAttr('style')
 
-    unless $(".ui-draggable-dragging").data('start_column') == column
-      $(".ui-draggable-dragging").prependTo($(@).find('.issues'))
-      $(@).removeClass 'over'
-      board_github_full_name = $('.board').data('github_full_name')
-      path = "/boards/#{board_github_full_name}/issues/#{issue}/move_to/#{column}"
-      $.get path
 
-  $(".droppable").on "dropout", (event, ui) ->
-    $(@).removeClass 'over'
 
-  $(".droppable").on "dropover", (event, ui) ->
-    $(@).addClass 'over'
+  #$(".droppable").droppable ->
+    #accept: ".issue"
 
-  $(".draggable").draggable ->
-    connectToSortable: ".issues",
-    helper: "clone",
-    revert: "valid",
-    snap: true,
-    scroll: true
+  #$(".droppable").on "drop", (event, ui) ->
+    #issue = $(".ui-draggable-dragging").data('number')
+    #column = $(@).data('column')
+    #$(".ui-draggable-dragging").removeAttr('style')
 
-  $(".draggable").on "dragstart", ( event, ui ) ->
-    $(@).before('<div class="empty-issue"></div>')
-    $('.empty-issue', $(@).parent()).css 'height', $(@).outerHeight()
-    $(@).data start_column: $(@).parents('.board-column').data('column')
+    #unless $(".ui-draggable-dragging").data('start_column') == column
+      #$(".ui-draggable-dragging").prependTo($(@).find('.issues'))
+      #$(@).removeClass 'over'
+      #board_github_name = $('.board').data('github_name')
+      #path = "/boards/#{board_github_name}/issues/#{issue}/move_to/#{column}"
+      #$.get path
 
-  $(".draggable").on "drag", ( event, ui ) ->
-    ui.position.top -= $(@).parent().scrollTop()
-    $(@).closest('.scroller').scrollTop = $(@).closest('.scroller').scrollHeight
+  #$(".droppable").on "dropout", (event, ui) ->
+    #$(@).removeClass 'over'
 
-  $(".draggable").on "dragstop", ( event, ui ) ->
-    $(@).removeAttr('style')
-    $('.empty-issue').remove()
-    $('.board-column').removeClass 'over'
+  #$(".droppable").on "dropover", (event, ui) ->
+    #$(@).addClass 'over'
 
-  $(".draggable").on "dragcreate", ( event, ui ) ->
+
+
+
+  #$(".draggable").draggable ->
+    #connectToSortable: ".issues",
+    #helper: "clone",
+    #revert: "valid",
+    #snap: true,
+    #scroll: true
+
+  #$(".draggable").on "dragstart", ( event, ui ) ->
+    #$(@).before('<div class="empty-issue"></div>')
+    #$('.empty-issue', $(@).parent()).css 'height', $(@).outerHeight()
+    #$(@).data start_column: $(@).parents('.board-column').data('column')
+
+  #$(".draggable").on "drag", ( event, ui ) ->
+    #ui.position.top -= $(@).parent().scrollTop()
+    #$(@).closest('.scroller').scrollTop = $(@).closest('.scroller').scrollHeight
+
+  #$(".draggable").on "dragstop", ( event, ui ) ->
+    #$(@).removeAttr('style')
+    #$('.empty-issue').remove()
+    #$('.board-column').removeClass 'over'
+
+  #$(".draggable").on "dragcreate", ( event, ui ) ->
+
+
+  #$('.issues').sortable ->
+    #revert: true,
+
+  #$('.issue').on 'sortremove', ->
+    #console.log
+
+  #$(".issues")
+    #.sortable ->
+      #connectWith: ".issues",
+      #handle: ".issue .title",
+      #placeholder: "issue-placeholder ui-corner-all"
+    #.disableSelection()
+
+  #$(".issue")
+    #.addClass("ui-widget ui-widget-content ui-helper-clearfix ui-corner-all")
+    #.find(".title")
+      #.addClass("ui-widget-header ui-corner-all")
+      #.prepend("<span class='ui-icon ui-icon-minusthick issue-toggle'></span>")

--- a/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
+++ b/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
@@ -6,72 +6,24 @@ $(document).on 'page:change', ->
     connectWith: '.issues'
   $('.issues').disableSelection()
 
+  $(".droppable").droppable ->
+    accept: ".issue"
 
+  $(".droppable").on "drop", (event, ui) ->
+    issue = $(".ui-sortable-helper").data('number')
+    column = $(@).data('column')
+    $(".ui-draggable-dragging").removeAttr('style')
 
+    unless $(".ui-draggable-dragging").data('start_column') == column
+      $(".ui-draggable-dragging").prependTo($(@).find('.issues'))
+      $(@).removeClass 'over'
+      board_github_name = $('.board').data('github_name')
+      path = "/boards/#{board_github_name}/issues/#{issue}/move_to/#{column}"
+      $.get path
 
-  #$(".droppable").droppable ->
-    #accept: ".issue"
+  $(".droppable").on "dropout", (event, ui) ->
+    $(@).removeClass 'over'
 
-  #$(".droppable").on "drop", (event, ui) ->
-    #issue = $(".ui-draggable-dragging").data('number')
-    #column = $(@).data('column')
-    #$(".ui-draggable-dragging").removeAttr('style')
-
-    #unless $(".ui-draggable-dragging").data('start_column') == column
-      #$(".ui-draggable-dragging").prependTo($(@).find('.issues'))
-      #$(@).removeClass 'over'
-      #board_github_name = $('.board').data('github_name')
-      #path = "/boards/#{board_github_name}/issues/#{issue}/move_to/#{column}"
-      #$.get path
-
-  #$(".droppable").on "dropout", (event, ui) ->
-    #$(@).removeClass 'over'
-
-  #$(".droppable").on "dropover", (event, ui) ->
-    #$(@).addClass 'over'
-
-
-
-
-  #$(".draggable").draggable ->
-    #connectToSortable: ".issues",
-    #helper: "clone",
-    #revert: "valid",
-    #snap: true,
-    #scroll: true
-
-  #$(".draggable").on "dragstart", ( event, ui ) ->
-    #$(@).before('<div class="empty-issue"></div>')
-    #$('.empty-issue', $(@).parent()).css 'height', $(@).outerHeight()
-    #$(@).data start_column: $(@).parents('.board-column').data('column')
-
-  #$(".draggable").on "drag", ( event, ui ) ->
-    #ui.position.top -= $(@).parent().scrollTop()
-    #$(@).closest('.scroller').scrollTop = $(@).closest('.scroller').scrollHeight
-
-  #$(".draggable").on "dragstop", ( event, ui ) ->
-    #$(@).removeAttr('style')
-    #$('.empty-issue').remove()
-    #$('.board-column').removeClass 'over'
-
-  #$(".draggable").on "dragcreate", ( event, ui ) ->
-
-
-  #$('.issues').sortable ->
-    #revert: true,
-
-  #$('.issue').on 'sortremove', ->
-    #console.log
-
-  #$(".issues")
-    #.sortable ->
-      #connectWith: ".issues",
-      #handle: ".issue .title",
-      #placeholder: "issue-placeholder ui-corner-all"
-    #.disableSelection()
-
-  #$(".issue")
-    #.addClass("ui-widget ui-widget-content ui-helper-clearfix ui-corner-all")
-    #.find(".title")
-      #.addClass("ui-widget-header ui-corner-all")
-      #.prepend("<span class='ui-icon ui-icon-minusthick issue-toggle'></span>")
+  $(".droppable").on "dropover", (event, ui) ->
+    $(@).addClass 'over'
+    $(@).find('.issues').css('height', $(@).height())

--- a/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
+++ b/app/assets/javascripts/pages/p-boards-show/drag_and_drop.js.coffee
@@ -1,10 +1,27 @@
 $(document).on 'page:change', ->
   return unless document.body.id == 'boards_show'
 
-  $('.issues').sortable connectWith: '.issues'
   $('.issues').sortable
-    connectWith: '.issues'
+    connectWith: '.issues',
   $('.issues').disableSelection()
+
+  # сохранение порядка тикетов, если он изменился
+  $('.issues').on 'sortupdate', (event, ui) ->
+    column = $(event.target).closest('.board-column').data('column')
+    board_github_name = $('.board').data('github_name')
+    path = "/boards/#{board_github_name}/columns/#{column}"
+
+    if $(event.target).sortable('serialize')
+      issues = $(event.target).sortable('serialize')
+    else
+      # колонка стала пустой
+      issues =  { issues: ['empty'] }
+      console.log issues
+
+    $.ajax
+      url: path,
+      method: 'PATCH',
+      data: issues
 
   $(".droppable").droppable ->
     accept: ".issue"

--- a/app/assets/javascripts/pages/p-boards-show/issue-modal.js.coffee
+++ b/app/assets/javascripts/pages/p-boards-show/issue-modal.js.coffee
@@ -54,12 +54,12 @@ $(document).on 'modal:load', '.b-issue-modal', ->
 
     issue = $current_issue.data('number')
     column = $(@).data('column')
-    board_github_name = $('.board').data('github_name')
+    board = $('.board').data('github_full_name')
 
     $col_1 = $current_issue.closest('.board-column')
     $col_2 = $('.board-column[data-column="' + column + '"]')
-    col_1_url = "/boards/#{board_github_name}/columns/#{$col_1.data('column')}"
-    col_2_url = "/boards/#{board_github_name}/columns/#{$col_2.data('column')}"
+    col_1_url = "/boards/#{board}/columns/#{$col_1.data('column')}"
+    col_2_url = "/boards/#{board}/columns/#{$col_2.data('column')}"
 
     # класс активной колонки
     $('.move-to-column li').removeClass 'active'
@@ -72,10 +72,7 @@ $(document).on 'modal:load', '.b-issue-modal', ->
     $('.issues', $column).prepend(clone)
 
     # урл перемещения
-    board_github_full_name = $('.board').data('github_full_name')
-    issue = $current_issue.data('number')
-    column = $(@).data('column')
-    path = "/boards/#{board_github_full_name}/issues/#{issue}/move_to/#{column}"
+    path = "/boards/#{board}/issues/#{issue}/move_to/#{column}"
     $.get path
 
     # сохранение порядка тиетов в измененных колонках

--- a/app/assets/stylesheets/pages/p-boards-show.sass
+++ b/app/assets/stylesheets/pages/p-boards-show.sass
@@ -140,10 +140,6 @@
     overflow-y: auto
     min-height: 40px
 
-    //&.over
-      //+border-radius(4px)
-      //+box-shadow(0 0 40px rgba(63,63,63,0.1) inset)
-
     .add-user
       display: none
 
@@ -362,6 +358,3 @@
 
       &.close
         display: none
-
-  .ui-sortable-placeholder
-    background: red

--- a/app/assets/stylesheets/pages/p-boards-show.sass
+++ b/app/assets/stylesheets/pages/p-boards-show.sass
@@ -362,3 +362,6 @@
 
       &.close
         display: none
+
+  .ui-sortable-placeholder
+    background: red

--- a/app/controllers/columns_controller.rb
+++ b/app/controllers/columns_controller.rb
@@ -22,7 +22,7 @@ class ColumnsController < ApplicationController
     @column = @board.columns.find(params[:id])
 
     if params[:issues]
-       @column.update(issues: params[:issues].join(','))
+       @column.update(issues: params[:issues])
        render nothing: true
     else
       if @column.update(column_params)

--- a/app/controllers/columns_controller.rb
+++ b/app/controllers/columns_controller.rb
@@ -20,10 +20,16 @@ class ColumnsController < ApplicationController
 
   def update
     @column = @board.columns.find(params[:id])
-    if @column.update(column_params)
-      redirect_to board_url(@board)
+
+    if params[:issues]
+       @column.update(issues: params[:issues].join(','))
+       render nothing: true
     else
-      render 'edit'
+      if @column.update(column_params)
+        redirect_to board_url(@board)
+      else
+        render 'edit'
+      end
     end
   end
 
@@ -64,6 +70,6 @@ class ColumnsController < ApplicationController
   def column_params
     params
       .require(:column)
-      .permit(:name)
+      .permit(:name, :issues)
   end
 end

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -5,6 +5,8 @@ class Column < ActiveRecord::Base
   validates :name, presence: true
   validates :board, presence: true
 
+  serialize :issues
+
   def label_name
     "[#{order}] #{name}"
   end

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -18,7 +18,7 @@ class BoardBag
     Issue.new(labels: labels.map(&:name))
   end
 
-  def issues_of_column column
+  def column_issues column
     if column.issues
       ordered_issues = []
       column.issues.each do |i|

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -18,6 +18,27 @@ class BoardBag
     Issue.new(labels: labels.map(&:name))
   end
 
+  #def issues_of_column column
+    #ordered_issues = []
+
+    #if column.issues
+      #column.issues.split(',').each do |i|
+        #issues[column.id].reject(&:archive?).each do |issue|
+          #if i.to_i == issue.number
+            #ordered_issues << issue
+          #end
+        #end
+      #end
+
+    #else
+      #issues[column.id].reject(&:archive?).each do |issue|
+        #ordered_issues << issue
+      #end
+    #end
+
+    #ordered_issues
+  #end
+
   private
 
   def cache_key(posfix)

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -19,7 +19,6 @@ class BoardBag
   end
 
   def issues_of_column column
-
     if column.issues
       ordered_issues = []
       column.issues.each do |i|

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -18,26 +18,23 @@ class BoardBag
     Issue.new(labels: labels.map(&:name))
   end
 
-  #def issues_of_column column
-    #ordered_issues = []
+  def issues_of_column column
 
-    #if column.issues
-      #column.issues.split(',').each do |i|
-        #issues[column.id].reject(&:archive?).each do |issue|
-          #if i.to_i == issue.number
-            #ordered_issues << issue
-          #end
-        #end
-      #end
+    if column.issues
+      ordered_issues = []
+      column.issues.each do |i|
+        issues[column.id].reject(&:archive?).each do |issue|
+          if i.to_i == issue.number
+            ordered_issues << issue
+          end
+        end
+      end
+      ordered_issues
 
-    #else
-      #issues[column.id].reject(&:archive?).each do |issue|
-        #ordered_issues << issue
-      #end
-    #end
-
-    #ordered_issues
-  #end
+    else
+      issues[column.id].reject(&:archive?)
+    end
+  end
 
   private
 

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -20,20 +20,25 @@ class BoardBag
 
   def column_issues column
     if column.issues
-      column.issues.each_with_object([]) { |number, ordered_issues|
-        ordered_issues.concat(issues[column.id].select { |issue|
-          number.to_i == issue.number && !issue.archive?
-        })
-      }.
-      concat(issues[column.id].
-        select { |issue| !column.issues.include?(issue.number) }
-      )
+      ordered_issues(column).concat unordered_issues(column)
     else
       issues[column.id].reject(&:archive?)
     end
   end
 
   private
+
+  def ordered_issues column
+    column.issues.each_with_object([]) do |number, array|
+      array << issues[column.id].find do |issue|
+        number.to_i == issue.number && !issue.archive?
+      end
+    end
+  end
+
+  def unordered_issues column
+    issues[column.id].select { |issue| !column.issues.include?(issue.number.to_s) }
+  end
 
   def cache_key(posfix)
     [@board, "board_bag_#{posfix}"]

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -20,16 +20,14 @@ class BoardBag
 
   def column_issues column
     if column.issues
-      ordered_issues = []
-      column.issues.each do |i|
-        issues[column.id].reject(&:archive?).each do |issue|
-          if i.to_i == issue.number
-            ordered_issues << issue
-          end
-        end
-      end
-      ordered_issues
-
+      column.issues.each_with_object([]) { |number, ordered_issues|
+        ordered_issues.concat(issues[column.id].select { |issue|
+          number.to_i == issue.number && !issue.archive?
+        })
+      }.
+      concat(issues[column.id].
+        select { |issue| !column.issues.include?(issue.number) }
+      )
     else
       issues[column.id].reject(&:archive?)
     end

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -20,7 +20,7 @@ class BoardBag
 
   def column_issues column
     if column.issues
-      ordered_issues(column).concat unordered_issues(column)
+      ordered_issues(column) + unordered_issues(column)
     else
       issues[column.id].reject(&:archive?)
     end
@@ -30,14 +30,15 @@ class BoardBag
 
   def ordered_issues column
     column.issues.each_with_object([]) do |number, array|
-      array << issues[column.id].find do |issue|
-        number.to_i == issue.number && !issue.archive?
-      end
+      one_issue = issues[column.id].find { |issue| number.to_i == issue.number && !issue.archive? }
+      array << one_issue if one_issue.present?
     end
   end
 
   def unordered_issues column
-    issues[column.id].select { |issue| !column.issues.include?(issue.number.to_s) }
+    issues[column.id].select do |issue|
+      !ordered_issues(column).include?(issue) && !issue.archive?
+    end
   end
 
   def cache_key(posfix)

--- a/app/view_objects/board_bag.rb
+++ b/app/view_objects/board_bag.rb
@@ -18,7 +18,7 @@ class BoardBag
     Issue.new(labels: labels.map(&:name))
   end
 
-  def column_issues column
+  def column_issues(column)
     if column.issues
       ordered_issues(column) + unordered_issues(column)
     else
@@ -28,14 +28,14 @@ class BoardBag
 
   private
 
-  def ordered_issues column
+  def ordered_issues(column)
     column.issues.each_with_object([]) do |number, array|
       one_issue = issues[column.id].find { |issue| number.to_i == issue.number && !issue.archive? }
       array << one_issue if one_issue.present?
     end
   end
 
-  def unordered_issues column
+  def unordered_issues(column)
     issues[column.id].select do |issue|
       !ordered_issues(column).include?(issue) && !issue.archive?
     end

--- a/app/views/columns/_show.html.slim
+++ b/app/views/columns/_show.html.slim
@@ -20,5 +20,15 @@
     = render partial: 'issues/new', locals: { board_bag: @board_bag, issue: @board_bag.build_issue_new }
 
   .issues.scroller
-    - @board_bag.issues[column.id].reject(&:archive?).each do |issue|
-      = render partial: 'issues/show', locals: { issue: issue }
+    /= @board_bag.issues_of_column(column).each do |issue|
+      /= render partial: 'issues/show', locals: { issue: issue }
+
+    - if column.issues
+      - column.issues.split(',').each do |i|
+        - @board_bag.issues[column.id].reject(&:archive?).each do |issue|
+          - if i.to_i == issue.number
+            = render partial: 'issues/show', locals: { issue: issue }
+
+    - else
+      - @board_bag.issues[column.id].reject(&:archive?).each do |issue|
+        = render partial: 'issues/show', locals: { issue: issue }

--- a/app/views/columns/_show.html.slim
+++ b/app/views/columns/_show.html.slim
@@ -20,5 +20,5 @@
     = render partial: 'issues/new', locals: { board_bag: @board_bag, issue: @board_bag.build_issue_new }
 
   .issues.scroller
-    - @board_bag.issues_of_column(column).each do |i|
+    - @board_bag.column_issues(column).each do |i|
       = render partial: 'issues/show', locals: { issue: i }

--- a/app/views/columns/_show.html.slim
+++ b/app/views/columns/_show.html.slim
@@ -20,15 +20,5 @@
     = render partial: 'issues/new', locals: { board_bag: @board_bag, issue: @board_bag.build_issue_new }
 
   .issues.scroller
-    /= @board_bag.issues_of_column(column).each do |issue|
-      /= render partial: 'issues/show', locals: { issue: issue }
-
-    - if column.issues
-      - column.issues.split(',').each do |i|
-        - @board_bag.issues[column.id].reject(&:archive?).each do |issue|
-          - if i.to_i == issue.number
-            = render partial: 'issues/show', locals: { issue: issue }
-
-    - else
-      - @board_bag.issues[column.id].reject(&:archive?).each do |issue|
-        = render partial: 'issues/show', locals: { issue: issue }
+    - @board_bag.issues_of_column(column).each do |i|
+      = render partial: 'issues/show', locals: { issue: i }

--- a/app/views/columns/_show.html.slim
+++ b/app/views/columns/_show.html.slim
@@ -21,4 +21,4 @@
 
   .issues.scroller
     - @board_bag.column_issues(column).each do |i|
-      = render partial: 'issues/show', locals: { issue: i }
+      = render partial: 'issues/show', locals: { issue: i, column: column }

--- a/app/views/issues/_show.html.slim
+++ b/app/views/issues/_show.html.slim
@@ -1,4 +1,4 @@
-.issue.draggable class="#{issue.state} issue-#{issue.number}" data-number="#{issue.number}" id="issues_#{issue.number}"
+.issue.draggable class="#{issue.state} issue-#{issue.number}" data-number="#{issue.number}" id="issues_#{issue.number}" data-column="#{column.id}"
 
   = render partial: 'issues/labels', locals: { issue: issue, board: @board }
 

--- a/app/views/issues/_show.html.slim
+++ b/app/views/issues/_show.html.slim
@@ -1,4 +1,4 @@
-.issue.draggable class="#{issue.state} issue-#{issue.number}" data-number="#{issue.number}"
+.issue.draggable class="#{issue.state} issue-#{issue.number}" data-number="#{issue.number}" id="issues_#{issue.number}"
 
   = render partial: 'issues/labels', locals: { issue: issue, board: @board }
 

--- a/db/migrate/20150312190838_add_issues_order_to_columns.rb
+++ b/db/migrate/20150312190838_add_issues_order_to_columns.rb
@@ -1,0 +1,5 @@
+class AddIssuesOrderToColumns < ActiveRecord::Migration
+  def change
+    add_column :columns, :issues_numbers_ordered, :string
+  end
+end

--- a/db/migrate/20150312190838_add_issues_order_to_columns.rb
+++ b/db/migrate/20150312190838_add_issues_order_to_columns.rb
@@ -1,5 +1,5 @@
 class AddIssuesOrderToColumns < ActiveRecord::Migration
   def change
-    add_column :columns, :issues_numbers_ordered, :string
+    add_column :columns, :issues, :text
   end
 end

--- a/db/migrate/20150314045420_rename_column_in_columns.rb
+++ b/db/migrate/20150314045420_rename_column_in_columns.rb
@@ -1,0 +1,5 @@
+class RenameColumnInColumns < ActiveRecord::Migration
+  def change
+    rename_column :columns, :issues_numbers_ordered, :issues
+  end
+end

--- a/db/migrate/20150314045420_rename_column_in_columns.rb
+++ b/db/migrate/20150314045420_rename_column_in_columns.rb
@@ -1,5 +1,0 @@
-class RenameColumnInColumns < ActiveRecord::Migration
-  def change
-    rename_column :columns, :issues_numbers_ordered, :issues
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,12 +40,12 @@ ActiveRecord::Schema.define(version: 20150401181522) do
 
   create_table "boards", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "name",             limit: 255
-    t.string   "type",             limit: 255
+    t.string   "name"
+    t.string   "type"
     t.integer  "github_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "github_name",      limit: 255
+    t.string   "github_name"
     t.text     "settings"
     t.string   "github_full_name", limit: 500
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20150401181522) do
     t.integer  "order"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "issues"
+    t.text     "issues"
   end
 
   add_index "columns", ["board_id"], name: "index_columns_on_board_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 20150401181522) do
 
   create_table "columns", force: :cascade do |t|
     t.integer  "board_id"
-    t.string   "name",       limit: 255
-    t.string   "color",      limit: 255
+    t.string   "name"
+    t.string   "color"
     t.integer  "order"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -103,9 +103,9 @@ ActiveRecord::Schema.define(version: 20150401181522) do
   add_index "repo_histories", ["collected_on", "board_id"], name: "index_repo_histories_on_collected_on_and_board_id", unique: true
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",           limit: 255, null: false
-    t.string   "github_username", limit: 255, null: false
-    t.string   "remember_token",  limit: 255
+    t.string   "email",           null: false
+    t.string   "github_username", null: false
+    t.string   "remember_token"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20150401181522) do
     t.integer  "order"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "issues"
   end
 
   add_index "columns", ["board_id"], name: "index_columns_on_board_id"

--- a/spec/view_objects/board_bag_spec.rb
+++ b/spec/view_objects/board_bag_spec.rb
@@ -67,12 +67,12 @@ describe BoardBag do
     before do
       allow_any_instance_of(GithubApi).
         to receive(:board_issues).
-          and_return(
-            { column_1.id => [github_issue_1, github_issue_2, github_issue_3] }
-          )
+        and_return(
+          column_1.id => [github_issue_1, github_issue_2, github_issue_3]
+        )
     end
 
-    context 'with column.issues', focus: true do
+    context 'with column.issues' do
       let(:issues) { [github_issue_2.number, github_issue_1.number] }
       it { is_expected.to have(2).items }
       it { expect(subject.first).to eq github_issue_2 }

--- a/spec/view_objects/board_bag_spec.rb
+++ b/spec/view_objects/board_bag_spec.rb
@@ -73,7 +73,7 @@ describe BoardBag do
     end
 
     context 'with column.issues' do
-      let(:issues) { [github_issue_2.number, github_issue_3.number] }
+      let(:issues) { [github_issue_2.number.to_s, github_issue_3.number.to_s] }
       it { is_expected.to have(2).items }
       it { expect(subject.first).to eq github_issue_2 }
     end

--- a/spec/view_objects/board_bag_spec.rb
+++ b/spec/view_objects/board_bag_spec.rb
@@ -33,4 +33,55 @@ describe BoardBag do
     it { is_expected.to be_a(Issue) }
     its(:labels) { is_expected.to eq ['label_1'] }
   end
+
+  describe '#column_issues' do
+    let(:board) { build(:board, columns: [column_1, column_2]) }
+    let(:column_1) { build_stubbed(:column, name: 'backlog', order: 1, issues: issues) }
+    let(:column_2) { build_stubbed(:column, name: 'todo', order: 2) }
+    let(:issue_1_1) do
+      build_stubbed(
+        :issue_stat,
+        column: column_1,
+        number: github_issue_1.number
+      )
+    end
+    let(:issue_2_1) do
+      build_stubbed(
+        :issue_stat,
+        column: column_1,
+        number: github_issue_2.number
+      )
+    end
+    let(:issue_3_1) do
+      build_stubbed(
+        :issue_stat,
+        column: column_1,
+        number: github_issue_3.number,
+        archived_at: Time.now
+      )
+    end
+    let(:github_issue_1) { OpenStruct.new(number: 1) }
+    let(:github_issue_2) { OpenStruct.new(number: 2) }
+    let(:github_issue_3) { OpenStruct.new(number: 3, archive?: true) }
+    subject { bag.column_issues(column_1) }
+    before do
+      allow_any_instance_of(GithubApi).
+        to receive(:board_issues).
+          and_return(
+            { column_1.id => [github_issue_1, github_issue_2, github_issue_3] }
+          )
+    end
+
+    context 'with column.issues', focus: true do
+      let(:issues) { [github_issue_2.number, github_issue_1.number] }
+      it { is_expected.to have(2).items }
+      it { expect(subject.first).to eq github_issue_2 }
+    end
+
+    context 'without column.issues' do
+      let(:issues) { nil }
+      it { is_expected.to have(2).items }
+      it { expect(subject.first).to eq github_issue_1 }
+    end
+  end
 end

--- a/spec/view_objects/board_bag_spec.rb
+++ b/spec/view_objects/board_bag_spec.rb
@@ -73,7 +73,7 @@ describe BoardBag do
     end
 
     context 'with column.issues' do
-      let(:issues) { [github_issue_2.number, github_issue_1.number] }
+      let(:issues) { [github_issue_2.number, github_issue_3.number] }
       it { is_expected.to have(2).items }
       it { expect(subject.first).to eq github_issue_2 }
     end


### PR DESCRIPTION
@blackchestnut есть вопросы).

Чтобы сохранять порядок тикетов в колонке, добавила в таблицу `columns` поле `issues`.
Туда сохраняется строчка, типа `'1,3,4,6'` — это последовательность issues.munber, если колонка пустеет, то `'empty'`.

В `app/views/columns/_show.html.slim` вывожу теперь тикеты исходя из той строчки. Если `column.issues` пусто, то по-старому.

Проблема: логику вывода тикетов по порядку хотела вынести в `app/view_objects/board_bag.rb`.
Вроде код практически без изменений перенесла. Если в точке останова посмотреть, то данные (набор issue) выводятся как и раньше. Но во вьюхе рендерится сразу за тикетами в каждой колонке текстом код хеша данных по каждому тикету.

![2015-03-14 23 33 26](https://cloud.githubusercontent.com/assets/6046764/6653405/9bf74cae-caa2-11e4-8091-9803dd321348.png)

Как думаешь, в чем может быть проблема?
Что можешь посоветовать, куда лучше вынести этот код вывода тикетов по порядку?

— это было из-за знака `=` вместо `-` перед циклом во вьюхе
